### PR TITLE
Allow webrtc connection to exit iceGathering early

### DIFF
--- a/packages/common/src/typings.ts
+++ b/packages/common/src/typings.ts
@@ -18,6 +18,7 @@ export interface ServerOptions {
   ordered?: boolean
   maxRetransmits?: number
   maxPacketLifeTime?: number
+  minimumSrflxCandidates?: number
   cors?: CorsOptions
 }
 

--- a/packages/server/src/wrtc/webrtcConnection.ts
+++ b/packages/server/src/wrtc/webrtcConnection.ts
@@ -22,6 +22,7 @@ export default class WebRTCConnection extends DefaultConnection {
     this.options = {
       clearTimeout,
       setTimeout,
+      minimumSrflxCandidates,
       timeToHostCandidates: TIME_TO_HOST_CANDIDATES
     }
 
@@ -134,12 +135,12 @@ export default class WebRTCConnection extends DefaultConnection {
     const onIceCandidate = (ev: RTCPeerConnectionIceEvent) => {
       const { candidate } = ev
 
-      if (candidate.type === 'srflx') totalSrflxCandidates++
+      if (candidate && candidate.type === 'srflx') totalSrflxCandidates++
       // if (candidate) console.log('candidate nr.', totalIceCandidates, 'type', candidate.type)
 
       totalIceCandidates++
 
-      if (!candidate || (minimumSrflxCandidates !== -1 && totalSrflxCandidates >= minimumSrflxCandidates)) {
+      if (!candidate || (this.options.minimumSrflxCandidates !== -1 && totalSrflxCandidates >= this.options.minimumSrflxCandidates)) {
         options.clearTimeout(timeout)
         peerConnection.removeEventListener('icecandidate', onIceCandidate)
         deferred.resolve()


### PR DESCRIPTION
I know this isn't a fully fledged PR, I'm just seeing what you think of this

I've been running into the issue of iceGatheringState being stuck on 'gathering' even after receiving viable candidates, then hitting the timeout (10 seconds) which makes calls to /connections super slow. I'm not really sure why this is the case and based on your comment `// strangely something it takes a long time` it's the same for you. 

This allows the user to specify minimum srflx candidates that will stop iceGathering early.

The other option here would be to expose the timeout (TIME_TO_HOST_CANDIDATES) as a server option as 10 seconds is too long to wait anyway.