### PR TITLE
Allow CORS to be configured to allow Authorization

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -41,6 +41,7 @@ export interface EmitOptions {
 type CorsOptionsOriginFunction = (req: http.IncomingMessage) => string
 export interface CorsOptions {
   origin: string | CorsOptionsOriginFunction
+  allowAuthorization?: boolean
 }
 
 export interface EventCallbackClient {

--- a/packages/server/src/httpServer/setCors.ts
+++ b/packages/server/src/httpServer/setCors.ts
@@ -2,7 +2,7 @@ import http from 'http'
 import { CorsOptions } from '@geckos.io/common/lib/types'
 
 const SetCORS = (req: http.IncomingMessage, res: http.ServerResponse, cors: CorsOptions) => {
-  const { origin } = cors
+  const { origin, allowAuthorization } = cors
 
   if (typeof origin === 'function') {
     res.setHeader('Access-Control-Allow-Origin', origin(req))
@@ -13,7 +13,12 @@ const SetCORS = (req: http.IncomingMessage, res: http.ServerResponse, cors: Cors
   res.setHeader('Access-Control-Request-Method', '*')
   res.setHeader('Access-Control-Request-Headers', 'X-Requested-With, accept, content-type')
   res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET, POST')
-  res.setHeader('Access-Control-Allow-Headers', 'content-type')
+
+  if (allowAuthorization) {
+    res.setHeader('Access-Control-Allow-Headers', 'authorization,content-type')
+  } else {
+    res.setHeader('Access-Control-Allow-Headers', 'content-type')
+  }
 }
 
 export default SetCORS


### PR DESCRIPTION
Geckos version 1.6.0 introduces support for the HTTP authorization header on channel initialization. However, when connecting to a cross-origin geckos server, an authorized request will get denied because `authorization:` wasn't an allowed CORS header. This adds an option to the Geckos server CORS configuration object that allows the user to allow the `authorization:` header in a cross-origin context.

@yandeu 

P.S. Thank you for adding authorization! It simplified management of geckos channels for me significantly.