### PR TITLE
permit a null port

### DIFF
--- a/packages/client/src/geckos/channel.ts
+++ b/packages/client/src/geckos/channel.ts
@@ -19,11 +19,11 @@ export class ClientChannel {
   constructor(
     url: string,
     authorization: string | undefined,
-    port: number,
+    port: number | null,
     label: string,
     rtcConfiguration: RTCConfiguration
   ) {
-    this.url = `${url}:${port}`
+    this.url = port ? `${url}:${port}` : url
     this.connectionsManager = new ConnectionsManagerClient(this.url, authorization, label, rtcConfiguration)
     this.bridge = this.connectionsManager.bridge
 


### PR DESCRIPTION
I find this useful for putting geckos behind a reverse proxy. E.g. I'm using it like this:

```
const channel = geckos({ port: null, url: `${location.protocol}//${location.hostname}/geckos` })
```