### PR TITLE
Bump node-datachannel to ^0.1.8

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@geckos.io/common": "^2.0.0",
     "@yandeu/events": "0.0.5",
-    "node-datachannel": "0.1.5"
+    "node-datachannel": "^0.1.8"
   },
   "funding": {
     "url": "https://github.com/sponsors/yandeu"


### PR DESCRIPTION
This PR updates node-datachannel to v0.1.8. This is necessary to handle a thousand connections or more.