### PR TITLE
Add Dino Battle on Who is Using Geckos.Io session into documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ For now WebRTC in the best way to send fast (unordered and unreliable) messages 
 ## Who is using geckos.io
 
 - [DatTank.io](https://dattank.io/) - is a free multiplayer browser online tank game.
+- [DinoBattle.one](https://dinobattle.one/) - is a free multiplayer browser online dino battle royale 2D.
 
 ## Other cool Packages
 


### PR DESCRIPTION
I developed a game using Geckos.io.
This game is a 2D Battle royale multiplayer online.