### PR TITLE
Update dependencies

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@geckos.io/common": "^2.3.0",
     "@yandeu/events": "0.0.6",
-    "node-datachannel": "0.4.1"
+    "node-datachannel": "0.4.2"
   },
   "funding": {
     "url": "https://github.com/sponsors/yandeu"


### PR DESCRIPTION
This allows to install the package when NODE_ENV is set to production and no prebuild is available, see https://github.com/murat-dogan/node-datachannel/pull/154