### PR TITLE
Fix server.ts

### DIFF
--- a/packages/server/src/geckos/server.ts
+++ b/packages/server/src/geckos/server.ts
@@ -45,24 +45,10 @@ export class GeckosServer {
   listen(port: number = 9208) {
     this._port = port
 
-    // create the server
-    this.server = http.createServer()
-
-    // on server close event
-    const promises: Promise<void>[] = []
-    this.server.once('close', async () => {
-      for (const [_, connection] of Array.from(this.connectionsManager.connections)) {
-        promises.push(connection.close())
-      }
-      await Promise.all(promises)
-
-      await promiseWithTimeout(cleanup(), 2000)
-
-      bridge.removeAllListeners()
-    })
-
-    // add all routes
-    HttpServer(this.server, this.connectionsManager, this._cors)
+    // add a new server if not added already
+    if (!this.server) {
+      this.addServer(http.createServer())
+    }
 
     // start the server
     this.server.listen(port, () => {


### PR DESCRIPTION
### Problem

When adding a custom server like:
```typescript
import https from "https" // <--- Notice httpS

server = https.createServer({
  key: fs.readFileSync("/etc/letsencrypt/live/max-ok.com/privkey.pem"),
  cert: fs.readFileSync("/etc/letsencrypt/live/max-ok.com/fullchain.pem"),
})
```

And run:
```typescript
io.addServer(server)

io.listen()
```

It would not use the server provided, but create another one right inside of the `.listen()`:
```typescript
 listen(port: number = 9208) {
    this._port = port

    // create the server
    this.server = http.createServer()  // <------- CREATING ANOTHER SERVER

    // on server close event
    const promises: Promise<void>[] = []
    this.server.once('close', async () => {
      for (const [_, connection] of Array.from(this.connectionsManager.connections)) {
        promises.push(connection.close())
      }
      await Promise.all(promises)

      await promiseWithTimeout(cleanup(), 2000)

      bridge.removeAllListeners()
    })

    // add all routes
    HttpServer(this.server, this.connectionsManager, this._cors)

    // start the server
    this.server.listen(port, () => {
      console.log(`Geckos.io signaling server is running on port ${port}`)
    })
  }
```

### This PR fixes it

----

Secondly, this chunk is duplicated in both: `listen()` and `addServer()` so we can reduce it and keep it [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself):
```typescript
    // on server close event
    const promises: Promise<void>[] = []
    this.server.once('close', async () => {
      for (const [_, connection] of Array.from(this.connectionsManager.connections)) {
        promises.push(connection.close())
      }
      await Promise.all(promises)
      await promiseWithTimeout(cleanup(), 2000)
      bridge.removeAllListeners()
    })
    HttpServer(this.server, this.connectionsManager, this._cors)
```