### PR TITLE
Upgrade to node-datachannel@0.22.0

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@geckos.io/common": "^3.0.0",
     "@yandeu/events": "0.0.6",
-    "node-datachannel": "0.8.0"
+    "node-datachannel": "0.22.0"
   },
   "funding": {
     "url": "https://github.com/sponsors/yandeu"

--- a/packages/server/src/wrtc/connectionsManager.ts
+++ b/packages/server/src/wrtc/connectionsManager.ts
@@ -69,9 +69,7 @@ export default class ConnectionsManagerServer {
     const dc_config: DataChannelInitConfig = {
       maxPacketLifeTime,
       maxRetransmits,
-      reliability: {
-        unordered: !ordered
-      }
+      unordered: !ordered
     }
 
     // WebRTCConnection configuration


### PR DESCRIPTION
Upgrading the node-datachannel from **0.8.0** to **0.22.0**

I think it can overlap this MR: https://github.com/geckosio/geckos.io/pull/293