### PR TITLE
Add reliable option for server.room().emit()

### DIFF
--- a/packages/server/src/geckos/server.ts
+++ b/packages/server/src/geckos/server.ts
@@ -118,13 +118,23 @@ export class GeckosServer {
    */
   room(roomId: Types.RoomId = undefined) {
     return {
-      emit: (eventName: Types.EventName, data: Types.Data) => {
+      emit: (eventName: Types.EventName, data: Types.Data, options?: Types.EmitOptions) => {
         this.connections.forEach((connection: WebRTCConnection) => {
           const { channel } = connection
           const { roomId: channelRoomId } = channel
 
           if (roomId === channelRoomId) {
-            channel.emit(eventName, data)
+            if (options && options.reliable) {
+              makeReliable(options, (id: string) =>
+                channel.emit(eventName, {
+                  MESSAGE: data,
+                  RELIABLE: 1,
+                  ID: id
+                })
+              )
+            } else {
+              channel.emit(eventName, data)
+            }
           }
         })
       }

--- a/packages/server/src/geckos/server.ts
+++ b/packages/server/src/geckos/server.ts
@@ -7,7 +7,6 @@ import WebRTCConnection from '../wrtc/webrtcConnection.js'
 import { bridge } from '../deps.js'
 import { cleanup } from '../wrtc/nodeDataChannel.js'
 import http from 'http'
-import { makeReliable } from '../deps.js'
 import { promiseWithTimeout } from '../deps.js'
 
 export class GeckosServer {
@@ -99,16 +98,7 @@ export class GeckosServer {
   emit(eventName: Types.EventName, data: Types.Data, options?: Types.EmitOptions) {
     this.connections.forEach((connection: WebRTCConnection) => {
       const { channel } = connection
-
-      if (options && options.reliable) {
-        makeReliable(options, (id: string) =>
-          channel.emit(eventName, {
-            MESSAGE: data,
-            RELIABLE: 1,
-            ID: id
-          })
-        )
-      } else channel.emit(eventName, data)
+      channel.emit(eventName, data, options)
     })
   }
 
@@ -124,17 +114,7 @@ export class GeckosServer {
           const { roomId: channelRoomId } = channel
 
           if (roomId === channelRoomId) {
-            if (options && options.reliable) {
-              makeReliable(options, (id: string) =>
-                channel.emit(eventName, {
-                  MESSAGE: data,
-                  RELIABLE: 1,
-                  ID: id
-                })
-              )
-            } else {
-              channel.emit(eventName, data)
-            }
+            channel.emit(eventName, data, options)
           }
         })
       }


### PR DESCRIPTION
The reliable option can be used with channel.emit() ([code here](https://github.com/geckosio/geckos.io/blob/master/packages/server/src/geckos/channel.ts#L208-L220)), however it cannot be used with server.room().emit(). server.room.emit uses channel.emit, so the option just needs to be captured and passed on.

The clientchannel's .on() ([located here](https://github.com/geckosio/geckos.io/blob/master/packages/client/src/geckos/channel.ts#L142-L177)) will now capture a reliable option passed to server.room().emit() as it does from channel.emit().

While doing this, I noticed the original server.emit command also unnecessarily tries to do the reliable deduplicating itself when it could be passed on and done by channel.emit anyways.

Let me know if there are other considerations I've missed. Thanks!